### PR TITLE
add OSRG logo

### DIFF
--- a/src/components/RightSidebar/MoreMenu.astro
+++ b/src/components/RightSidebar/MoreMenu.astro
@@ -3,6 +3,7 @@ import ThemeToggleButton from './ThemeToggleButton.jsx';
 import * as CONFIG from '../../config.js';
 const {editHref} = Astro.props;
 const showMoreSection = (CONFIG.COMMUNITY_INVITE_URL || editHref);
+import OSRGLogo from '../Header/OSRGLogo.astro';
 ---
 <style>
   .edit-on-github {
@@ -29,26 +30,10 @@ const showMoreSection = (CONFIG.COMMUNITY_INVITE_URL || editHref);
   }
   {CONFIG.COMMUNITY_INVITE_URL && 
     <li class={`header-link depth-2`}>
-      <a href={CONFIG.COMMUNITY_INVITE_URL} target="_blank">
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          data-prefix="fas"
-          data-icon="comment-alt"
-          class="svg-inline--fa fa-comment-alt fa-w-16"
-          role="img"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 512 512"
-          height="1em"
-          width="1em"
-        >
-          <path
-            fill="currentColor"
-            d="M448 0H64C28.7 0 0 28.7 0 64v288c0 35.3 28.7 64 64 64h96v84c0 9.8 11.2 15.5 19.1 9.7L304 416h144c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64z"
-          ></path>
-        </svg>
-        <span>Join our community</span>
-      </a>
+        <a href={CONFIG.COMMUNITY_INVITE_URL} target="_blank">
+          <OSRGLogo size={16} />
+          <span>Join our community</span>
+        </a>
     </li>
   }
 </ul>


### PR DESCRIPTION
* Related Issue #23 
Main Work Summary
  - Add OSG icon to Join Community link


It looks a little small and seems to push the text over, but it's the same size as the Github icon 

-----
Add any images or videos you think are relevant (i.e. Cypress video of a test passing) 

| Light  | Dark |
| ------------- | ------------- |
|![image](https://user-images.githubusercontent.com/3941006/138567049-eb8fdd8c-92ba-4985-b382-c18e7c67cf4c.png)|![image](https://user-images.githubusercontent.com/3941006/138567057-1c40cf1f-30a6-492b-a342-dbd0d4d8ad30.png)|

