### PR TITLE
Add latest Github markdown format & use universal emojis. 

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,8 +18,8 @@ export default /** @type {import('astro').AstroUserConfig} */ ({
     tailwindConfig: './tailwind.config.js',
   },
   markdownOptions: {
-    remarkPlugins: [
-      [import('remark-emoji'), { behavior: 'prepend'}]
-    ]
+    remarkPlugins: 
+    ['remark-emoji', 'remark-gfm', 'remark-slug', '@silvenon/remark-smartypants'],
+    rehypePlugins: ['rehype-autolink-headings'],
   }
 });

--- a/package.json
+++ b/package.json
@@ -13,8 +13,13 @@
   },
   "dependencies": {
     "@docsearch/react": "^1.0.0-alpha.27",
+    "@silvenon/remark-smartypants": "^1.0.0",
     "@tailwindcss/typography": "^0.4.1",
-    "remark-emoji": "^3.0.1"
+    "rehype-autolink-headings": "^6.1.0",
+    "remark-emoji": "^3.0.1",
+    "remark-gfm": "^3.0.0",
+    "remark-sectionize": "^1.1.1",
+    "remark-slug": "^7.0.0"
   },
   "devDependencies": {
     "@astrojs/renderer-preact": "^0.2.2",

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -6,27 +6,34 @@ import MoreMenu from '../RightSidebar/MoreMenu.astro';
 import TableOfContents from '../RightSidebar/TableOfContents.tsx';
 ---
 <style>
-
+      .content {
+        padding: 0;
+        max-width: 75ch;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
       .content > section {
         margin-bottom: 4rem;
       }
       .block {
         display: block;
       }
-
       @media (min-width: 50em) {
         .sm\:hidden {
           display: none;
         }
       }
 </style>
-<article id="article">
+
+<article id="article" class="content">
     <section class="main-section">
         <h1 class="content-title" id="overview">{title}</h1>
         <nav class="block sm:hidden">
             <TableOfContents client:media="(max-width: 50em)" headers={headers}/>
         </nav>
-        <slot class="" />
+        <slot />
     </section>
     <nav class="block sm:hidden">
         <MoreMenu editHref={githubEditUrl}/>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -6,9 +6,10 @@ import Header from '../components/Header/Header.astro';
 import PageContent from '../components/PageContent/PageContent.astro';
 import LeftSidebar from '../components/LeftSidebar/LeftSidebar.astro';
 import RightSidebar from '../components/RightSidebar/RightSidebar.astro';
+
 import * as CONFIG from "../config.ts";
 
-const { content = {} } = Astro.props;
+const { content } = Astro.props;
 const currentPage = Astro.request.url.pathname;
 const currentFile = `src/pages/${currentPage.replace(/\/$/, "")}.md`;
 console.dir({ currentPage, currentFile });
@@ -112,7 +113,9 @@ const githubEditUrl = CONFIG.GITHUB_EDIT_URL && (CONFIG.GITHUB_EDIT_URL + curren
       </aside>
       <div id="grid-main">
         <PageContent content={content} githubEditUrl={githubEditUrl}>
+
           <slot />
+
         </PageContent>
       </div>
       <aside id="grid-right" class="grid-sidebar" title="Table of Contents">

--- a/src/pages/docs/en/tutorial-quest.md
+++ b/src/pages/docs/en/tutorial-quest.md
@@ -14,6 +14,7 @@ The OSS Raid Group is what happens when you combine MMORPGs (Gamification), Mob 
 
 For those who aren't aware of these 'gamer' terms, and even those that are; here are the definitions we use when operating as a Raid Guild.
 
+
 | Phrase                        | Definition                                                                                                                                                                                                                  |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Raid                          | A Raid is the OSS project's issue that we are working to resolve - see how we [converted react-hooks-testing-library to TypeScript](https://github.com/testing-library/react-hooks-testing-library/pull/520) for an example |
@@ -21,6 +22,7 @@ For those who aren't aware of these 'gamer' terms, and even those that are; here
 | Open Source Raid Guild (OSRG) | The collective noun for all contributors to the Raid                                                                                                                                                                        |
 | Raid Repo                     | The repository for the current Raid that has been forked into the OpenSourceRaidGuild Org                                                                                                                                   |
 | Dungeon                       | The working fork repository that the Raid is operating inside of; multiple Raids can occur in one Dungeon but only one Raid at a time                                                                                       |
+
 
 ## Storyline Quest (mission) :scroll:
 
@@ -45,7 +47,7 @@ What it's about:
   3. Our impact can be potentially high; in a few days
 -->
 
-## Join Us! :smiling_face_with_three_hearts:
+## Join Us! :smiling_face_with_3_hearts:
 
 Anyone is welcome to participate in our Raids - no matter your experience level! Never contributed to an OSS project? No worries! We are all learning something or another, so come along for the ride!
 


### PR DESCRIPTION
When adding any markdown plugins to Astro, Astro entirely removes styling. Added back all of the default styling, in addition to the emoji support. Also updated the markdown format to use the latest Github markdown format and switched an emoji from Apple standard to global standard.